### PR TITLE
Refactor: Update YAML report path and naming convention

### DIFF
--- a/dependency_analyzer.py
+++ b/dependency_analyzer.py
@@ -265,9 +265,10 @@ def generate_yaml_reports(dependency_analysis_map):
             continue
 
         # Determine YAML file path
-        group_path_elements = group.split('.')
-        sanitized_artifact_filename = artifact.replace(':', '_') + ".yml"
-        yaml_file_path_elements = ['_data'] + group_path_elements + [sanitized_artifact_filename]
+        # New filename format: group+artifact.yml
+        new_filename = f"{group}+{artifact}.yml"
+        # New path: libraries/new_filename.yml
+        yaml_file_path_elements = ['libraries', new_filename]
         yaml_file_path = os.path.join(*yaml_file_path_elements)
         
         # Prepare G:A level data from current run


### PR DESCRIPTION
The script `dependency_analyzer.py` has been updated to change the output directory and filename format for YAML reports.

Previously, YAML reports were saved under a directory structure derived from the group ID within the `_data` folder (e.g., `_data/com/github/barteksc/pdfium-android.yml`).

The new changes implement the following:
1. The output directory for YAML reports is now `libraries`.
2. The filename convention is now `group_id+artifact_id.yml` (e.g., `com.github.barteksc+pdfium-android.yml`), and these files are stored directly in the `libraries` folder without intermediate subdirectories based on the group ID.

These modifications affect the `generate_yaml_reports` function in `dependency_analyzer.py`.